### PR TITLE
CSC example added to public example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # BankID B2B Signing example application
 
-This is an example application that demonstrates how to use the BankID B2B Signing API.
+This is example applications that demonstrates how to use the BankID B2B Signing API and the BankID B2B CSC signing API.
 
 **This project is not actively maintained.** It is provided as a reference implementation and may not be up to date with the latest changes in the BankID API.
 
 ## Documentation
-The documentation for the BankID B2B Signing API can be found at [BankID B2B Signing API](https://developer.bankid.no/bankid-esign-provider/apis/b2b/).
+
+The documentation for the BankID B2B Signing API can be found
+at [BankID B2B Signing API](https://developer.bankid.no/bankid-esign-provider/apis/b2b/v0/B2B-Bankid-Signer/).
+The documentation for the BankID B2B CSC signing API can be found
+at [BankID B2B CSC Signing API](https://developer.bankid.no/bankid-esign-provider/apis/b2b/csc/b2b-csc-overview/).
 
 ## Prerequisite 
-- To use the example application, you need to have an OIDC client registered with BankID OIDC.
+
+- To use the example applications, you need to have an OIDC client registered with BankID OIDC.
 - You need to have the `esign/b2b` scope enabled for your client.
 - You need to use `private_key_jwt` authentication method, not `basic`.
 - You also need to use DPoP authentication when calling BankID OIDC and the B2B signing API.
@@ -48,8 +53,8 @@ Update `src/main/java/no/bankid/esign/merchant/b2b/environment/BankIDOIDCServers
 
 public final static OIDCServerSpec bankIDOidcServer = bankIDOidcCurrentKeyAuthentication;
 ```
-  
-- In test environments `basic` may work, but not in production, where `private_key_jwt` is required
+
+- In test environments `basic` authentication may work, but not in production, where `private_key_jwt` is required
 - The example code supports both, but `private_key_jwt` is required in production.
 
 
@@ -72,12 +77,14 @@ To run the application, `cd` to the `b2b-client` directory:
 cd b2b-client
 ```
 
-Then run the application with:
+Then run the applications with: (I could not make this run in a power shell window, only in command prompt window)
 
 ```bash
-mvn exec:java
+mvn exec:java -Dexec.mainClass="no.bankid.esign.merchant.b2b.B2BMiniExample"
+mvn exec:java -Dexec.mainClass="no.bankid.esign.merchant.b2b.CSCMiniExample"
 ```
 
 If running from an IDE, make sure to set the working directory to the `b2b-client` when running the `B2BMiniExample`
-application.
+or the `CSCMiniExample` application.
 
+Good luck!

--- a/b2b-api-for-feign/pom.xml
+++ b/b2b-api-for-feign/pom.xml
@@ -117,6 +117,28 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>api-b2b-csc-java-feign-v0</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>
+                                https://developer.bankid.no/bankid-esign-provider/apis/b2b/csc/b2b-csc-v2.0.external.yaml
+                            </inputSpec>
+                            <modelPackage>no.bankid.esign.feign.api.b2b.csc.model</modelPackage>
+                            <apiPackage>no.bankid.esign.feign.api.b2b.csc.api</apiPackage>
+                            <generatorName>java</generatorName>
+                            <configOptions>
+                                <sourceFolder>src/gen/java/main</sourceFolder>
+                                <interfaceOnly>true</interfaceOnly>
+                                <library>feign</library>
+                                <openApiNullable>false</openApiNullable>
+                                <useJakartaEe>true</useJakartaEe>
+                                <useTags>true</useTags>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/b2b-client/pom.xml
+++ b/b2b-client/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.77</version>
+            <version>1.82</version>
         </dependency>
 
         <dependency>
@@ -30,6 +30,12 @@
             <artifactId>oauth2-oidc-sdk</artifactId>
             <version>11.23.1</version>
         </dependency>
+        <dependency>
+            <groupId>eu.europa.ec.joinup.sd-dss</groupId>
+            <artifactId>dss-crl-parser-stream</artifactId>
+            <version>6.3</version>
+        </dependency>
+
 
     </dependencies>
 
@@ -49,9 +55,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.5.0</version>
-                <configuration>
-                    <mainClass>no.bankid.esign.merchant.b2b.B2BMiniExample</mainClass>
-                </configuration>
             </plugin>
 
         </plugins>

--- a/b2b-client/src/main/doc/B2B-CSC-Signing.puml
+++ b/b2b-client/src/main/doc/B2B-CSC-Signing.puml
@@ -1,0 +1,47 @@
+@startuml
+'https://plantuml.com/sequence-diagram
+
+autonumber
+Actor Customer as customer #green
+participant ClientApp as client #green
+database CustomerDB as db #green
+participant BankIDOIDC as oidc
+participant B2BCscSigner as signer
+participant BankIDService as bidj
+participant BankIDVault as certstore
+
+title How to use a client for B2B CSC signing with BankID OIDC
+
+== use ==
+client -> db: get key for authentication
+client -> client: create DPoP proof for oidc
+client -> oidc: authenticate (jwt, dpop) with esign/b2b
+oidc --> client: signed access_token with esign/b2b (dpop bound)
+client -> client: create DPoP proof for signer
+client -[#red]> signer: csc/v2/credentials/list (access_token, dpop proof)
+signer -> bidj: get certificates for client-id
+bidj -> certstore: get complete certchain for client-id
+certstore --> bidj: bankid-cert and credentialId for client-id
+bidj --> signer: bankid-cert and credentialId for client-id
+client -> client: build data to sign(bankid-cert, documents)\ncompute hashes for\nPAdES,XAdES or CAdES signing
+client -> client: create DPoP proof for signer
+client -[#red]> signer: csc/v2/signatures/signHash (access_token, dpop proof, hashes, credentialId)
+signer -> signer: verify access_token, dop proof, sign parameters
+signer -> bidj: pkcs1 - sign hashes using bankid-cert for given credentialId
+bidj -> bidj: get OCSP for signer cert from VA
+bidj -> certstore: sign each hash for credentialId
+certstore -> certstore: sign with private bankid key(credentialId)
+note right of certstore
+  This signing is only an
+  encryption of the hash
+  using the private key.
+end note
+certstore --> bidj: pkcs1 signatures
+bidj --> signer: pkcs1 signatures, OCSP
+signer --> client: pkcs1 signatures, OCSP
+client -> client: embed signatures and OCSP into documents
+client --> customer: signed documents
+
+
+
+@enduml

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/B2BMiniExample.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/B2BMiniExample.java
@@ -1,18 +1,9 @@
 package no.bankid.esign.merchant.b2b;
 
-import com.nimbusds.jose.JWSHeader;
 import no.bankid.esign.feign.api.b2b.v0.model.*;
-import no.bankid.esign.merchant.b2b.dpop.DPoPGenerator;
-import no.bankid.esign.merchant.b2b.dpop.NullDPopGenerator;
-import no.bankid.esign.merchant.b2b.dpop.RS256DPopGenerator;
-import no.bankid.esign.merchant.b2b.environment.BankIDOIDCServers;
-import no.bankid.esign.merchant.b2b.environment.BankIDOIDCServers.OIDCServerSpec;
-import no.bankid.esign.merchant.b2b.feignclients.*;
 import no.bankid.esign.merchant.b2b.feignclients.OAuth2TokenApi.TokenResponse;
-import no.bankid.esign.merchant.b2b.feignclients.OpenIDWellKnownApi.OpenIDConfig;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,14 +14,13 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 
-import static no.bankid.esign.merchant.b2b.environment.BankIDOIDCServers.AuthType.PRIVATE_KEY_JWT;
+import static no.bankid.esign.merchant.b2b.environment.Globals.VARS;
 
 public class B2BMiniExample {
 
     public static void main(String[] args) throws Exception {
-        B2BMiniExample test = new B2BMiniExample();
-        InterceptingFeignClient.traceTokens = true;
-        test.showPublicKeyJwk();
+        var test = new B2BMiniExample();
+        VARS.showPublicKeyJwk();
         test.doASimpleTextSigning();
         test.doBuildSdoFromCms(0,2,1,3,2,2,2);
         test.doBuildSdoFromCms(0,2,4,1,3,5);
@@ -40,17 +30,6 @@ public class B2BMiniExample {
         String hash2 = sha256("Juletrær har vi egentlig nok av");
         test.doAHashSigningStandardFormat(hash1, hash2);
         test.doAHashSigningPAdESFormat(hash1, hash2);
-    }
-
-    /**
-     * Shows the public key to register in BankID OIDC when client is using private_key_jwt authentication
-     */
-    private void showPublicKeyJwk() {
-        if (bankIDOIDCServer.authType() != PRIVATE_KEY_JWT) {
-            System.out.println("Client " + bankIDOIDCServer.clientId() + " does not use private_key_jwt authentication");
-            return;
-        }
-        System.out.println("\nFor client " + bankIDOIDCServer.clientId() + " using BankID OIDC at " + bankIDOIDCServer.oidcRoot() + " register this key in BankID OIDC:\n" + PrettyPrint.prettyPrintJson(bankIDOIDCServer.privateKeyAssertionBuilder().getPublicKeyAsJsonMap()) + "\n");
     }
 
     /**
@@ -69,11 +48,11 @@ public class B2BMiniExample {
         // Stronger authentication then just a client_secret may be required,
         // ex: private_key_jwt which uses a private key pr. clientId,
         //     public keys are registered in or accessible from the OIDC server
-        TokenResponse tokenResponse = getAccessTokenFromKeycloak();
+        TokenResponse tokenResponse = VARS.getAccessTokenFromKeycloak();
 
         // Call the signer endpoint
-        String sdoB64 = b2bSigner.b2BSignApi()
-            .withATAndDPoP(tokenResponse.access_token, b2bSigner.sdoFromTextUri())
+        String sdoB64 = VARS.b2bSigner.b2BSignApi()
+                .withATAndDPoP(tokenResponse.access_token, VARS.b2bSigner.sdoFromTextUri())
             .sdoFromText(sdoFromTextRequest)
             .getSdo();
 
@@ -81,12 +60,14 @@ public class B2BMiniExample {
         dumpSdo(sdoB64);
     }
 
+    /**
+     * Builds SDOs from pdf documents using BankID OIDC b2b signing.
+     */
     private void doSomePdfSigning(String... fns) throws Exception {
         // Here is what we will sign:
         SdosFromDocumentsRequest sdosFromDocumentsRequest = new SdosFromDocumentsRequest();
 
-        for (int i = 0; i < fns.length; i++) {
-            String fn = fns[i];
+        for (String fn : fns) {
             Path filePath = Paths.get("src/main/resources/" + fn);
 
             byte[] fileContent = null;
@@ -97,34 +78,34 @@ public class B2BMiniExample {
             }
 
             TbsDocument tbsDocumentsItem = new TbsDocument()
-                .pdf(Base64.getEncoder().encodeToString(fileContent))
-                .description("Filen er " + fn);
+                    .pdf(Base64.getEncoder().encodeToString(fileContent))
+                    .description("Filen er " + fn);
             sdosFromDocumentsRequest.addTbsDocumentsItem(tbsDocumentsItem);
         }
 
-        TokenResponse tokenResponse = getAccessTokenFromKeycloak();
+        TokenResponse tokenResponse = VARS.getAccessTokenFromKeycloak();
         // Call the signer endpoint
-        b2bSigner
+        VARS.b2bSigner
             .b2BSignApi()
-            .withATAndDPoP(tokenResponse.access_token, b2bSigner.sdosFromDocsUri())
+                .withATAndDPoP(tokenResponse.access_token, VARS.b2bSigner.sdosFromDocsUri())
             .sdosFromDocuments(sdosFromDocumentsRequest)
             .forEach(hashAndSdo -> dumpSdo(hashAndSdo.getSdo()));
     }
 
     private void doAHashSigningPAdESFormat(String ... hashes) {
-        TokenResponse tokenResponse = getAccessTokenFromKeycloak();
+        TokenResponse tokenResponse = VARS.getAccessTokenFromKeycloak();
 
-        CmsesFromHashes200Response cmsesFromHashes200Response = b2bSigner.b2BSignApi()
-                .withATAndDPoP(tokenResponse.access_token, b2bSigner.padesCmsesFromHashesUri())
+        CmsesFromHashes200Response cmsesFromHashes200Response = VARS.b2bSigner.b2BSignApi()
+                .withATAndDPoP(tokenResponse.access_token, VARS.b2bSigner.padesCmsesFromHashesUri())
                 .padesCmsesFromHashes(Arrays.asList(hashes));
         dumpCmsFromHashes("Pades", cmsesFromHashes200Response);
     }
 
     private void doAHashSigningStandardFormat(String ... hashes) {
-        TokenResponse tokenResponse = getAccessTokenFromKeycloak();
+        TokenResponse tokenResponse = VARS.getAccessTokenFromKeycloak();
 
-        CmsesFromHashes200Response cmsesFromHashes200Response = b2bSigner.b2BSignApi()
-                .withATAndDPoP(tokenResponse.access_token, b2bSigner.cmsesFromHashesUri())
+        CmsesFromHashes200Response cmsesFromHashes200Response = VARS.b2bSigner.b2BSignApi()
+                .withATAndDPoP(tokenResponse.access_token, VARS.b2bSigner.cmsesFromHashesUri())
                 .cmsesFromHashes(Arrays.asList(hashes));
 
         dumpCmsFromHashes("BankID", cmsesFromHashes200Response);
@@ -152,19 +133,19 @@ public class B2BMiniExample {
             .description(CmsAndOcspExampleData.TEXT_DESCRIPTION);
 
         List<CmsAndOcsp> signatureList = new ArrayList<>();
-        for (int i = 0; i < includedSignatures.length; i++) {
-            signatureList.add(CmsAndOcspExampleData.cmsAndOcsp[includedSignatures[i]]);
+        for (int includedSignature : includedSignatures) {
+            signatureList.add(CmsAndOcspExampleData.cmsAndOcsp[includedSignature]);
         }
 
         SdoFromCmsesRequest sdoFromCmsRequest = new SdoFromCmsesRequest()
             .cmsAndOcsps(signatureList)
             .document(tbsDocument);
 
-        TokenResponse tokenResponse = getAccessTokenFromKeycloak();
+        TokenResponse tokenResponse = VARS.getAccessTokenFromKeycloak();
 
         // Call the signer endpoint
-        String sdoB64 = b2bSigner.b2BSignApi()
-            .withATAndDPoP(tokenResponse.access_token, b2bSigner.sdoFromCmsUri())
+        String sdoB64 = VARS.b2bSigner.b2BSignApi()
+                .withATAndDPoP(tokenResponse.access_token, VARS.b2bSigner.sdoFromCmsUri())
             .sdoFromCmses(sdoFromCmsRequest)
             .getSdo();
 
@@ -180,71 +161,6 @@ public class B2BMiniExample {
             new String(Base64.getDecoder().decode(sdoB64), StandardCharsets.UTF_8)));
     }
 
-    private TokenResponse getAccessTokenFromKeycloak() {
-        if (BankIDOIDCServers.bankIDOidcServer.authType() == PRIVATE_KEY_JWT) {
-            return getAccessTokenFromKeycloakPrivateKeyJwt();
-        } else {
-            return getAccessTokenFromKeycloakBasicAuth();
-        }
-    }
-    /**
-     * Get an access token from the BankID OIDC server using basic authentication
-     */
-    private TokenResponse getAccessTokenFromKeycloakBasicAuth() {
-        return oAuth2TokenApi
-            .withBasicAndDPoP(
-                bankIDOIDCServer.clientId(),
-                bankIDOIDCServer.clientSecret(),
-                URI.create(openIDConfig.token_endpoint))
-                .getTokenBasic(
-            "client_credentials",
-            "esign/b2b"
-        );
-    }
-
-    /**
-     * Get an access token from the BankID OIDC server using private key authentication
-     */
-    private TokenResponse getAccessTokenFromKeycloakPrivateKeyJwt() {
-        // We must build a signed JWT to use as client_assertion
-        // The signing is using the PrivateKeyAssertionBuilder built on the private key of the clientId
-        // The public key is registered in the OIDC server
-
-        return oAuth2TokenApi
-                .withDPoP(URI.create(openIDConfig.token_endpoint))
-                .getTokenPrivateKeyJwt(
-                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                        bankIDOIDCServer.privateKeyAssertionBuilder()
-                                .buildAssertion(bankIDOIDCServer.clientId(), URI.create(openIDConfig.token_endpoint)),
-                        "client_credentials",
-                        "esign/b2b"
-                );
-    }
-
-    private final OIDCServerSpec bankIDOIDCServer = BankIDOIDCServers.bankIDOidcServer;
-
-    final OpenIDConfig openIDConfig;
-    final FeignClientWithDPoPProofAndAccessToken<OAuth2TokenApi> oAuth2TokenApi;
-    final boolean canUseDPoP;
-    final B2BSigner b2bSigner;
-
-    /**
-     * Initialize the urls and clients needed for the test
-     */
-    public B2BMiniExample() {
-        // Get config from BankID OIDC well known endpoint
-        this.openIDConfig = OpenIDWellKnownApi.create(bankIDOIDCServer.oidcRoot()).getOpenIDConfig();
-
-        this.canUseDPoP = // requests gives "DPoP proof is missing" if supported and missing
-            openIDConfig.dpop_signing_alg_values_supported != null &&
-                Arrays.asList(openIDConfig.dpop_signing_alg_values_supported).contains("RS256");
-        DPoPGenerator dPoPGenerator = canUseDPoP ? new RS256DPopGenerator() : new NullDPopGenerator();
-
-        this.oAuth2TokenApi = OAuth2TokenApi.create(openIDConfig.token_endpoint, dPoPGenerator);
-
-
-        this.b2bSigner = new B2BSigner(bankIDOIDCServer.b2bSignerRootUrl(), dPoPGenerator);
-    }
     public static String sha256(String someString) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/B2BMiniExample.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/B2BMiniExample.java
@@ -1,6 +1,7 @@
 package no.bankid.esign.merchant.b2b;
 
 import no.bankid.esign.feign.api.b2b.v0.model.*;
+import no.bankid.esign.merchant.b2b.feignclients.InterceptingFeignClient;
 import no.bankid.esign.merchant.b2b.feignclients.OAuth2TokenApi.TokenResponse;
 
 import java.io.IOException;
@@ -20,6 +21,10 @@ public class B2BMiniExample {
 
     public static void main(String[] args) throws Exception {
         var test = new B2BMiniExample();
+
+        // Set this to true to see the access token and DPoP proof in the console
+        InterceptingFeignClient.traceTokens = false;
+
         VARS.showPublicKeyJwk();
         test.doASimpleTextSigning();
         test.doBuildSdoFromCms(0,2,1,3,2,2,2);

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/CSCAdapter.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/CSCAdapter.java
@@ -1,0 +1,133 @@
+package no.bankid.esign.merchant.b2b;
+
+import eu.europa.esig.dss.enumerations.SignatureAlgorithm;
+import no.bankid.esign.feign.api.b2b.csc.model.CscCredentialsList200Response;
+import no.bankid.esign.feign.api.b2b.csc.model.CscCredentialsListRequest;
+import no.bankid.esign.feign.api.b2b.csc.model.CscSignaturesSignHashRequest;
+import no.bankid.esign.merchant.b2b.feignclients.OAuth2TokenApi;
+import org.bouncycastle.asn1.ocsp.BasicOCSPResponse;
+import org.bouncycastle.cert.ocsp.BasicOCSPResp;
+import org.bouncycastle.cert.ocsp.OCSPException;
+import org.bouncycastle.cert.ocsp.OCSPRespBuilder;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+import static no.bankid.esign.merchant.b2b.environment.Globals.VARS;
+
+/**
+ * A simple class holding the csc credentials list result and which uses credentialId and certs from that when signing.
+ * <p>
+ * When calling computeSignatures, the implementation shall ensure that the credentials list has been loaded,
+ * and then use the credential ID from that to call the signHash endpoint.
+ * <p>
+ * The implementation should also administrate the access token, see {@link CSCAdapter::createAdapter()}
+ */
+public interface CSCAdapter {
+    CscCredentialsList200Response getCredentialsList200Response();
+
+    OCSPAndSignedHashes computeSignatures(SignatureAlgorithm signatureAlgorithm, List<String> b64Hashes);
+
+    /**
+     * Holder of the OCSP response and the signed hashes, as returned by the CSC signHash endpoint,
+     * with the addition of the full OCSP response (including the basic OCSP response and the signature) in base64 format.
+     *
+     * @param basicOcspB64
+     * @param signedHashesB64
+     */
+    record OCSPAndSignedHashes(String basicOcspB64, List<String> signedHashesB64) {
+        String fullOcspB64() {
+            byte[] fullOcspBytesFromBasicBytes = getFullOcspBytesFromBasicBytes(Base64.getDecoder().decode(basicOcspB64));
+            return Base64.getEncoder().encodeToString(fullOcspBytesFromBasicBytes);
+        }
+    }
+
+    /**
+     * Adding response succesful to a basic OCSP response, to create a full OCSP response as expected by some validators.
+     */
+    static byte[] getFullOcspBytesFromBasicBytes(byte[] basicOcspBytes) {
+        BasicOCSPResponse basicResponse = BasicOCSPResponse.getInstance(basicOcspBytes);
+        BasicOCSPResp basicOCSPResp = new BasicOCSPResp(basicResponse);
+        byte[] ocspBytes;
+        try {
+            ocspBytes = new OCSPRespBuilder().build(OCSPRespBuilder.SUCCESSFUL, basicOCSPResp).getEncoded();
+        } catch (OCSPException | IOException e) {
+            throw new RuntimeException(e);
+        }
+        return ocspBytes;
+    }
+
+    /**
+     * Create a CSCAdapter which initially creates an access token.
+     * This access token might of course expire, you should handle that case.
+     * Usage in this example code is to create a new adapter for each operation,
+     * so token expiry is not supposed to be an issue.
+     */
+    static CSCAdapter createAdapter() {
+        return new CSCAdapter() {
+            final OAuth2TokenApi.TokenResponse tokenResponse = VARS.getAccessTokenFromKeycloak();
+
+            CscCredentialsList200Response credentialsList200Response = null;
+
+            @Override
+            public CscCredentialsList200Response getCredentialsList200Response() {
+                if (credentialsList200Response != null) {
+                    return credentialsList200Response;
+                }
+
+                // We ask for "everything" in the credentials list request, to get all the information we need in one call
+                var credentialsListRequest = new CscCredentialsListRequest()
+                        .certificates("chain")
+                        .credentialInfo(true)
+                        .certInfo(true);
+                credentialsList200Response = VARS.b2bSigner
+                        .b2BCscApi()
+                        .withATAndDPoP(tokenResponse.access_token, VARS.b2bSigner.cscCredentialsListUri())
+                        .cscCredentialsList(credentialsListRequest);
+
+                System.out.println("CSC credentials list : " + credentialsList200Response);
+
+                assert credentialsList200Response.getCredentialInfos() != null;
+                return credentialsList200Response;
+            }
+
+            @Override
+            public OCSPAndSignedHashes computeSignatures(SignatureAlgorithm signatureAlgorithm, List<String> b64Hashes) {
+                ensureLoaded();
+                // We need to get the credentials list to know which credential ID to use for signing
+                // We take the first credential, and for BankID B2B CSC there should only be one credential.
+                // The credential ID is needed for the signHash request
+
+                // Remark: the credential ID does not have to be the same between calls, so doing a refresh
+                // should at least be done after a restart or error. An update of the signer cert on server side causes
+                // new credential IDs to be issued.
+
+                String credentialID = credentialsList200Response.getCredentialInfos().getFirst().getCredentialID();
+                var signaturesSignHashRequest = new CscSignaturesSignHashRequest()
+                        .hashes(b64Hashes)
+                        .credentialID(credentialID)
+                        .signAlgo(CSCAlgorithms.getSafeOid(signatureAlgorithm))
+                        .hashAlgorithmOID(CSCAlgorithms.getSafeOid(signatureAlgorithm.getDigestAlgorithm()));
+
+                var signaturesSignHash200Response = VARS.b2bSigner
+                        .b2BCscApi()
+                        .withATAndDPoP(tokenResponse.access_token, VARS.b2bSigner.cscSignHashUri())
+                        .cscSignaturesSignHash(signaturesSignHashRequest);
+
+                System.out.println("CSC signHashes : " + signaturesSignHash200Response);
+
+                return new OCSPAndSignedHashes(
+                        signaturesSignHash200Response.getOcspResponse(),
+                        signaturesSignHash200Response.getSignatures()
+                );
+            }
+
+            private void ensureLoaded() {
+                if (credentialsList200Response == null) {
+                    getCredentialsList200Response();
+                }
+            }
+        };
+    }
+}

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/CSCAlgorithms.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/CSCAlgorithms.java
@@ -1,0 +1,66 @@
+package no.bankid.esign.merchant.b2b;
+
+import eu.europa.esig.dss.enumerations.DigestAlgorithm;
+import eu.europa.esig.dss.enumerations.EncryptionAlgorithm;
+import eu.europa.esig.dss.enumerations.SignatureAlgorithm;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static eu.europa.esig.dss.enumerations.SignatureAlgorithm.RSA_SSA_PSS_SHA1_MGF1;
+
+/**
+ * Defines the sets of algorithms used in B2B CSC signing and provides utility methods for handling OIDs
+ * Supported algorithms when using B2B CSC for signature generation, we know these are supported by B2B CSC
+ * The info endpoint may be used to query supported algorithms from the CSC, and we could use that to
+ * build these sets dynamically. For now these sets are hardcoded.
+ * <p>
+ * These sets are used in example code to demonstrate signing with various algorithms.
+ * <p>
+ * Remark that the SignatureAlgorithm enum does not provide OIDs for RSASSA-PSS algorithms, so to get OIDs for
+ * both signature and hash algorithms, use the getSafeOid methods in this class.
+ * <p>
+ * Note that the CSC may support other algorithms than these, the info endpoint could be used to verify.
+ * These are just a set of algorithms we know are supported and want to use in our examples.
+ */
+public class CSCAlgorithms {
+    public final static Set<DigestAlgorithm> CSC_HASH_ALGS = EnumSet.of(
+            DigestAlgorithm.SHA256,
+            DigestAlgorithm.SHA384,
+            DigestAlgorithm.SHA512
+    );
+    public final static Set<EncryptionAlgorithm> CSC_ENCRYPTION_ALGS = EnumSet.of(
+            EncryptionAlgorithm.RSA,
+            EncryptionAlgorithm.RSASSA_PSS
+    );
+    public final static Set<SignatureAlgorithm> CSC_SIGNATURE_ALGS;
+
+    static {
+        Set<SignatureAlgorithm> sigAlgs = EnumSet.noneOf(SignatureAlgorithm.class);
+        for (DigestAlgorithm hashAlg : CSC_HASH_ALGS) {
+            for (EncryptionAlgorithm encAlg : CSC_ENCRYPTION_ALGS) {
+                sigAlgs.add(SignatureAlgorithm.getAlgorithm(encAlg, hashAlg));
+            }
+        }
+        CSC_SIGNATURE_ALGS = sigAlgs;
+    }
+
+    public static String getSafeOid(SignatureAlgorithm signatureAlgorithm) {
+        String oid = signatureAlgorithm.getOid();
+        if (oid == null && signatureAlgorithm.name().contains("PSS")) {
+            return RSA_SSA_PSS_SHA1_MGF1.getOid(); // "1.2.840.113549.1.1.10"
+        }
+        if (oid == null) {
+            throw new IllegalStateException("No OID found for signature algorithm: " + signatureAlgorithm);
+        }
+        return oid;
+    }
+
+    public static String getSafeOid(DigestAlgorithm hashAlgorithm) {
+        String oid = hashAlgorithm.getOid();
+        if (oid == null) {
+            throw new IllegalStateException("No OID found for hash algorithm: " + hashAlgorithm);
+        }
+        return oid;
+    }
+}

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/CSCMiniExample.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/CSCMiniExample.java
@@ -1,0 +1,136 @@
+package no.bankid.esign.merchant.b2b;
+
+import eu.europa.esig.dss.enumerations.DigestAlgorithm;
+import eu.europa.esig.dss.enumerations.EncryptionAlgorithm;
+import eu.europa.esig.dss.enumerations.SignatureAlgorithm;
+import no.bankid.esign.feign.api.b2b.csc.model.CscCredentialsList200Response;
+import no.bankid.esign.feign.api.b2b.csc.model.CscInfoRequest;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.security.cert.X509Certificate;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.util.Base64;
+import java.util.List;
+
+import static java.security.cert.CertificateFactory.getInstance;
+import static no.bankid.esign.merchant.b2b.environment.Globals.VARS;
+
+public class CSCMiniExample {
+
+    static {
+        // Needs bouncycastle to use NoneWithRSAandMGF1
+        BouncyCastleProvider provider = new BouncyCastleProvider();
+        Security.addProvider(provider);
+    }
+
+    public static void main(String[] args) throws Exception {
+        var test = new CSCMiniExample();
+        VARS.showPublicKeyJwk();
+
+        test.doSomeCscInfo();
+        test.doSomeCscSignHash();
+    }
+
+    /**
+     * Example of how to call the CSC signHash endpoint.
+     * Also validates the signature using the public key from the credentials list endpoint.
+     * <p>
+     * REMARK that the CSC signHash endpoint returns a signature in PKCS#1 v1.5 format.
+     * What is actually happening on the serverside when signing is only an encryption, i.e. actual  signature
+     * algorithm used is noneWithRSA or noneWithRSASSA-PSS, depending on the signature algorithm you choose to sign with.
+     * <p>
+     * Therefore in order to validate the signature, we may either use
+     * hash and noneWith...
+     * or we use the original data and RSASSA-PSS with the same parameters as used by the server.
+     * <p>
+     * Parameters
+     */
+    private void doSomeCscSignHash() {
+        String stringToHash = "Tristesser";
+        String hash1 = sha512(stringToHash);
+        CSCAdapter adapter = CSCAdapter.createAdapter();
+
+        SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.getAlgorithm(EncryptionAlgorithm.RSASSA_PSS, DigestAlgorithm.SHA512);
+
+        var ocspAndSignature = adapter.computeSignatures(signatureAlgorithm, List.of(hash1));
+
+        String signature = ocspAndSignature.signedHashesB64().getFirst();
+        System.out.println("Signature for hash1: " + signature);
+        CscCredentialsList200Response credentialsList200Response = adapter.getCredentialsList200Response();
+        var signerCert = getSignerCertificateFromCredentialsList(credentialsList200Response);
+
+        // Show how to validate signature using both the original data and the hash, to show the difference in parameters for the signature instance.
+        PublicKey signerPublicKey = signerCert.getPublicKey();
+        validatePSSSHA512Signature(stringToHash.getBytes(StandardCharsets.UTF_8), signature, signerPublicKey, DataToSignType.ORIGINAL_DATA_BYTES);
+        validatePSSSHA512Signature(Base64.getDecoder().decode(hash1), signature, signerPublicKey, DataToSignType.HASH_BYTES);
+
+        System.out.println("Signer:" + signerCert.getSubjectX500Principal().getName("RFC1779"));
+        System.out.println("Signer returned from credentials list endpoint: " + credentialsList200Response.getCredentialInfos().getFirst().getCert().getSubjectDN());
+        // Code and ideas for validating the ocspResponse may be found in https://github.com/BankIDNorge/bankid-open-b2b-examples repository.
+    }
+
+    private void validatePSSSHA512Signature(byte[] tbs, String pkcs1SignatureB64, PublicKey publicKey, DataToSignType dataToSignType) {
+        try {
+            Signature sig = Signature.getInstance(dataToSignType == DataToSignType.ORIGINAL_DATA_BYTES ? "RSASSA-PSS" : "NoneWithRSAandMGF1");
+            // Default parameters for RSASSA-PSS with SHA-512,
+            // for SHA-384 use MGF1ParameterSpec.SHA384 and salt length 48,
+            // for SHA-256 use MGF1ParameterSpec.SHA256 and salt length 32
+            sig.setParameter(new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1));
+            sig.initVerify(publicKey);
+            sig.update(tbs);
+            boolean valid = sig.verify(Base64.getDecoder().decode(pkcs1SignatureB64));
+            System.out.println("Signature valid: " + valid + " for data type: " + dataToSignType);
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | SignatureException |
+                 InvalidKeyException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Example of how to call the CSC info endpoint, which returns information about the credentials available for signing, supported algorithms etc.
+     */
+    private void doSomeCscInfo() {
+        CscInfoRequest infoRequest = new CscInfoRequest().lang("nn");
+        var infoPost = VARS.b2bSigner.b2BCscApi().theApi().cscInfo(infoRequest);
+        System.out.println("CSC Info endpoint response using post request: " + infoPost);
+    }
+
+    /**
+     * Helper method to compute the sha256 hash of a string, and return it in base64 format.
+     */
+    public static String sha512(String someString) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+            byte[] hash = digest.digest(someString.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Helper to extract the public key from the first certificate in credentialsListResponse.
+     */
+    private X509Certificate getSignerCertificateFromCredentialsList(CscCredentialsList200Response credentialsListResponse) {
+        try {
+            var firstCredential = credentialsListResponse.getCredentialInfos().getFirst();
+            var certObj = firstCredential.getCert();
+            var certChain = certObj.getCertificates(); // List<String> Base64-encoded certs, one leaf, zero or more intermediates, one root
+            String leafCertBase64 = certChain.getFirst();
+            byte[] certBytes = Base64.getDecoder().decode(leafCertBase64);
+            var certificateFactory = getInstance("X.509");
+            return (X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(certBytes));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to extract certificate", e);
+        }
+    }
+
+    private enum DataToSignType {
+        HASH_BYTES,
+        ORIGINAL_DATA_BYTES
+    }
+}

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/CSCMiniExample.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/CSCMiniExample.java
@@ -4,7 +4,10 @@ import eu.europa.esig.dss.enumerations.DigestAlgorithm;
 import eu.europa.esig.dss.enumerations.EncryptionAlgorithm;
 import eu.europa.esig.dss.enumerations.SignatureAlgorithm;
 import no.bankid.esign.feign.api.b2b.csc.model.CscCredentialsList200Response;
+import no.bankid.esign.feign.api.b2b.csc.model.CscCredentialsListRequest;
 import no.bankid.esign.feign.api.b2b.csc.model.CscInfoRequest;
+import no.bankid.esign.merchant.b2b.feignclients.InterceptingFeignClient;
+import no.bankid.esign.merchant.b2b.feignclients.OAuth2TokenApi;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.io.ByteArrayInputStream;
@@ -19,6 +22,13 @@ import java.util.List;
 import static java.security.cert.CertificateFactory.getInstance;
 import static no.bankid.esign.merchant.b2b.environment.Globals.VARS;
 
+/**
+ * A simple example showing how to call the CSC info, credentials list and signHash endpoints,
+ * and how to validate the signature returned from the signHash endpoint using the public key from the credentials list endpoint.
+ * <p>>
+ * The example dumps results from the endpoints to the console; inspecting that may be useful to understand what information is
+ * given, and where to find that.
+ */
 public class CSCMiniExample {
 
     static {
@@ -29,10 +39,50 @@ public class CSCMiniExample {
 
     public static void main(String[] args) throws Exception {
         var test = new CSCMiniExample();
+
+        // Set this to true to see the access token and DPoP proof in the console
+        InterceptingFeignClient.traceTokens = false;
+
         VARS.showPublicKeyJwk();
 
         test.doSomeCscInfo();
+        test.doSomeCscCredentialsInfo();
         test.doSomeCscSignHash();
+    }
+
+    /**
+     * Example of how to call the CSC info endpoint, which returns information about the credentials available for signing, supported algorithms etc.
+     */
+    private void doSomeCscInfo() {
+        CscInfoRequest infoRequest = new CscInfoRequest().lang("nn");
+        var infoPost = VARS.b2bSigner.b2BCscApi().theApi().cscInfo(infoRequest);
+        System.out.println("CSC Info endpoint response: " + infoPost);
+    }
+
+    /**
+     * Example of how to call the CSC credentials list endpoint, which returns the list of credentials available for signing,
+     * including the public key certificates and credential IDs.
+     * <p>
+     * - The credential ID is needed to call the signHash endpoint,
+     * - the public key certificate, together with eventual other naming info are needed
+     * - sometimes for setting values in the document to sign (orgnumber, bankname etc.)
+     * - building the hash to sign (ex: in PAdES, the certificate is needed to build the signed attributes which are part of the data to sign)
+     * - validating the signature returned from the signHash endpoint, using the public key.
+     */
+    private void doSomeCscCredentialsInfo() {
+        final OAuth2TokenApi.TokenResponse tokenResponse = VARS.getAccessTokenFromKeycloak();
+
+        // We ask for "everything" in the credentials list request, to get all the information we need in one call
+        var credentialsListRequest = new CscCredentialsListRequest()
+                .certificates("chain")
+                .credentialInfo(true)
+                .certInfo(true);
+        var credentialsList200Response = VARS.b2bSigner
+                .b2BCscApi()
+                .withATAndDPoP(tokenResponse.access_token, VARS.b2bSigner.cscCredentialsListUri())
+                .cscCredentialsList(credentialsListRequest);
+
+        System.out.println("CSC credentials list response: " + credentialsList200Response);
     }
 
     /**
@@ -50,6 +100,7 @@ public class CSCMiniExample {
      * Parameters
      */
     private void doSomeCscSignHash() {
+        System.out.println("\nDoing some CSC signHash...");
         String stringToHash = "Tristesser";
         String hash1 = sha512(stringToHash);
         CSCAdapter adapter = CSCAdapter.createAdapter();
@@ -68,7 +119,7 @@ public class CSCMiniExample {
         validatePSSSHA512Signature(stringToHash.getBytes(StandardCharsets.UTF_8), signature, signerPublicKey, DataToSignType.ORIGINAL_DATA_BYTES);
         validatePSSSHA512Signature(Base64.getDecoder().decode(hash1), signature, signerPublicKey, DataToSignType.HASH_BYTES);
 
-        System.out.println("Signer:" + signerCert.getSubjectX500Principal().getName("RFC1779"));
+        System.out.println("Signer from certificate: " + signerCert.getSubjectX500Principal().getName("RFC1779"));
         System.out.println("Signer returned from credentials list endpoint: " + credentialsList200Response.getCredentialInfos().getFirst().getCert().getSubjectDN());
         // Code and ideas for validating the ocspResponse may be found in https://github.com/BankIDNorge/bankid-open-b2b-examples repository.
     }
@@ -90,14 +141,6 @@ public class CSCMiniExample {
         }
     }
 
-    /**
-     * Example of how to call the CSC info endpoint, which returns information about the credentials available for signing, supported algorithms etc.
-     */
-    private void doSomeCscInfo() {
-        CscInfoRequest infoRequest = new CscInfoRequest().lang("nn");
-        var infoPost = VARS.b2bSigner.b2BCscApi().theApi().cscInfo(infoRequest);
-        System.out.println("CSC Info endpoint response using post request: " + infoPost);
-    }
 
     /**
      * Helper method to compute the sha256 hash of a string, and return it in base64 format.

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/environment/Globals.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/environment/Globals.java
@@ -1,0 +1,94 @@
+package no.bankid.esign.merchant.b2b.environment;
+
+import no.bankid.esign.merchant.b2b.PrettyPrint;
+import no.bankid.esign.merchant.b2b.dpop.DPoPGenerator;
+import no.bankid.esign.merchant.b2b.dpop.NullDPopGenerator;
+import no.bankid.esign.merchant.b2b.dpop.RS256DPopGenerator;
+import no.bankid.esign.merchant.b2b.feignclients.*;
+
+import java.net.URI;
+import java.util.Arrays;
+
+import static no.bankid.esign.merchant.b2b.environment.BankIDOIDCServers.AuthType.PRIVATE_KEY_JWT;
+import static no.bankid.esign.merchant.b2b.environment.BankIDOIDCServers.bankIDOidcServer;
+
+public enum Globals {
+    VARS;
+
+    public final OpenIDWellKnownApi.OpenIDConfig openIDConfig;
+    public final FeignClientWithDPoPProofAndAccessToken<OAuth2TokenApi> oAuth2TokenApi;
+    public final boolean canUseDPoP;
+    public final B2BSigner b2bSigner;
+
+    Globals() {
+        // Get config from BankID OIDC well known endpoint
+        this.openIDConfig = OpenIDWellKnownApi.create(bankIDOidcServer.oidcRoot()).getOpenIDConfig();
+
+        this.canUseDPoP = // requests gives "DPoP proof is missing" if supported and missing
+                openIDConfig.dpop_signing_alg_values_supported != null &&
+                        Arrays.asList(openIDConfig.dpop_signing_alg_values_supported).contains("RS256");
+        DPoPGenerator dPoPGenerator = canUseDPoP ? new RS256DPopGenerator() : new NullDPopGenerator();
+
+        this.oAuth2TokenApi = OAuth2TokenApi.create(openIDConfig.token_endpoint, dPoPGenerator);
+        this.b2bSigner = new B2BSigner(bankIDOidcServer.b2bSignerRootUrl(), dPoPGenerator);
+
+        InterceptingFeignClient.traceTokens = true;
+    }
+
+    public OAuth2TokenApi.TokenResponse getAccessTokenFromKeycloak() {
+        if (bankIDOidcServer.authType() == PRIVATE_KEY_JWT) {
+            return getAccessTokenFromKeycloakPrivateKeyJwt();
+        } else {
+            return getAccessTokenFromKeycloakBasicAuth();
+        }
+    }
+
+    /**
+     * Get an access token from the BankID OIDC server using basic authentication
+     */
+    private OAuth2TokenApi.TokenResponse getAccessTokenFromKeycloakBasicAuth() {
+        return VARS.oAuth2TokenApi
+                .withBasicAndDPoP(
+                        bankIDOidcServer.clientId(),
+                        bankIDOidcServer.clientSecret(),
+                        URI.create(VARS.openIDConfig.token_endpoint))
+                .getTokenBasic(
+                        "client_credentials",
+                        "esign/b2b"
+                );
+    }
+
+    /**
+     * Get an access token from the BankID OIDC server using private key authentication
+     */
+    private OAuth2TokenApi.TokenResponse getAccessTokenFromKeycloakPrivateKeyJwt() {
+        // We must build a signed JWT to use as client_assertion
+        // The signing is using the PrivateKeyAssertionBuilder built on the private key of the clientId
+        // The public key is registered in the OIDC server
+
+        return VARS.oAuth2TokenApi
+                .withDPoP(URI.create(VARS.openIDConfig.token_endpoint))
+                .getTokenPrivateKeyJwt(
+                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                        bankIDOidcServer.privateKeyAssertionBuilder()
+                                .buildAssertion(bankIDOidcServer.clientId(), URI.create(VARS.openIDConfig.token_endpoint)),
+                        "client_credentials",
+                        "esign/b2b"
+                );
+    }
+
+    /**
+     * Shows the public key to register in BankID OIDC when client is using private_key_jwt authentication
+     */
+    public void showPublicKeyJwk() {
+        if (bankIDOidcServer.authType() != PRIVATE_KEY_JWT) {
+            System.out.println("Client " + bankIDOidcServer.clientId() + " does not use private_key_jwt authentication");
+            return;
+        }
+        System.out.println("\nFor client " + bankIDOidcServer.clientId() +
+                " using BankID OIDC at " + bankIDOidcServer.oidcRoot() +
+                " register this key in BankID OIDC:\n" +
+                PrettyPrint.prettyPrintJson(bankIDOidcServer.privateKeyAssertionBuilder().getPublicKeyAsJsonMap()) + "\n");
+    }
+
+}

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/environment/Globals.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/environment/Globals.java
@@ -31,8 +31,6 @@ public enum Globals {
 
         this.oAuth2TokenApi = OAuth2TokenApi.create(openIDConfig.token_endpoint, dPoPGenerator);
         this.b2bSigner = new B2BSigner(bankIDOidcServer.b2bSignerRootUrl(), dPoPGenerator);
-
-        InterceptingFeignClient.traceTokens = true;
     }
 
     public OAuth2TokenApi.TokenResponse getAccessTokenFromKeycloak() {

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/feignclients/B2BSigner.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/feignclients/B2BSigner.java
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Feign;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import no.bankid.esign.feign.api.b2b.csc.api.CscCredentialsApi;
+import no.bankid.esign.feign.api.b2b.csc.api.CscInfoApi;
+import no.bankid.esign.feign.api.b2b.csc.api.CscSignaturesApi;
+import no.bankid.esign.feign.api.b2b.csc.model.*;
 import no.bankid.esign.feign.api.b2b.v0.api.B2bSignApi;
 import no.bankid.esign.feign.api.b2b.v0.model.BidXml;
 import no.bankid.esign.feign.api.b2b.v0.model.MimeType;
@@ -18,9 +22,15 @@ import java.net.URI;
 public class B2BSigner {
 
     final FeignClientWithDPoPProofAndAccessToken<B2bSignApi> b2bSignApi;
+    final FeignClientWithDPoPProofAndAccessToken<B2bCscApi> b2bCscApi;
+
 
     public FeignClientWithDPoPProofAndAccessToken<B2bSignApi> b2BSignApi() {
         return b2bSignApi;
+    }
+
+    public FeignClientWithDPoPProofAndAccessToken<B2bCscApi> b2BCscApi() {
+        return b2bCscApi;
     }
 
     public URI sdoFromTextUri() {
@@ -43,6 +53,23 @@ public class B2BSigner {
     }
 
 
+    public URI cscInfoUri() {
+        return cscInfoUri;
+    }
+
+    public URI cscCredentialsInfoUri() {
+        return cscCredentialsInfoUri;
+    }
+
+    public URI cscCredentialsListUri() {
+        return cscCredentialsListUri;
+    }
+
+    public URI cscSignHashUri() {
+        return cscSignHashUri;
+    }
+
+
     final String b2bSignerRoot;
     final URI sdoFromTextUri;
     final URI sdoFromCmsUri;
@@ -50,6 +77,10 @@ public class B2BSigner {
     final URI cmsesFromHashesUri;
     final URI padesCmsesFromHashesUri;
 
+    final URI cscInfoUri;
+    final URI cscCredentialsInfoUri;
+    final URI cscCredentialsListUri;
+    final URI cscSignHashUri;
 
     public B2BSigner(String b2bSignerRootUrl, DPoPGenerator dPoP) {
         this.b2bSignerRoot = b2bSignerRootUrl;
@@ -59,11 +90,85 @@ public class B2BSigner {
         this.cmsesFromHashesUri = URI.create(b2bSignerRoot + "/v0/b2b/cmses_from_hashes");
         this.padesCmsesFromHashesUri = URI.create(b2bSignerRoot + "/v0/b2b/pades/cmses_from_hashes");
 
+        this.cscCredentialsInfoUri = URI.create(b2bSignerRoot + "/v0/b2b/csc/v2/credentials/info");
+        this.cscCredentialsListUri = URI.create(b2bSignerRoot + "/v0/b2b/csc/v2/credentials/list");
+        this.cscInfoUri = URI.create(b2bSignerRoot + "/v0/b2b/csc/v2/info");
+        this.cscSignHashUri = URI.create(b2bSignerRoot + "/v0/b2b/csc/v2/signatures/signHash");
+
         this.b2bSignApi = new FeignClientWithDPoPProofAndAccessToken<>(dPoP, Feign.builder()
             .client(new InterceptingFeignClient("B2BSigner"))
                 .encoder(new JacksonEncoder(feignObjectMapper()))
             .decoder(new JacksonDecoder())
             .target(B2bSignApi.class, b2bSignerRoot));
+
+        FeignClientWithDPoPProofAndAccessToken<CscInfoApi> cscInfoApi = new FeignClientWithDPoPProofAndAccessToken<>(dPoP, Feign.builder()
+                .client(new InterceptingFeignClient("CscInfoApi"))
+                .encoder(new JacksonEncoder(feignObjectMapper()))
+                .decoder(new JacksonDecoder())
+                .target(CscInfoApi.class, b2bSignerRoot));
+        FeignClientWithDPoPProofAndAccessToken<CscCredentialsApi> cscCredentialsApi = new FeignClientWithDPoPProofAndAccessToken<>(dPoP, Feign.builder()
+                .client(new InterceptingFeignClient("CscCredentialsApi"))
+                .encoder(new JacksonEncoder(feignObjectMapper()))
+                .decoder(new JacksonDecoder())
+                .target(CscCredentialsApi.class, b2bSignerRoot));
+        FeignClientWithDPoPProofAndAccessToken<CscSignaturesApi> cscSignaturesApi = new FeignClientWithDPoPProofAndAccessToken<>(dPoP, Feign.builder()
+                .client(new InterceptingFeignClient("CscSignaturesApi"))
+                .encoder(new JacksonEncoder(feignObjectMapper()))
+                .decoder(new JacksonDecoder())
+                .target(CscSignaturesApi.class, b2bSignerRoot));
+
+        this.b2bCscApi = new FeignClientWithDPoPProofAndAccessToken<>(dPoP,
+                new B2bCscApi() {
+                    @Override
+                    public CscCredentialsList200Response cscCredentialsList(CscCredentialsListRequest credentialsListRequest) {
+                        return cscCredentialsApi.theApi().cscCredentialsList(credentialsListRequest);
+                    }
+
+                    @Override
+                    public ApiResponse<CscCredentialsList200Response> cscCredentialsListWithHttpInfo(CscCredentialsListRequest credentialsListRequest) {
+                        return cscCredentialsApi.theApi().cscCredentialsListWithHttpInfo(credentialsListRequest);
+                    }
+
+                    @Override
+                    public CscInfoGet200Response cscInfo(CscInfoRequest infoRequest) {
+                        return cscInfoApi.theApi().cscInfo(infoRequest);
+                    }
+
+                    @Override
+                    public ApiResponse<CscInfoGet200Response> cscInfoWithHttpInfo(CscInfoRequest infoRequest) {
+                        return cscInfoApi.theApi().cscInfoWithHttpInfo(infoRequest);
+                    }
+
+                    @Override
+                    public CscInfoGet200Response cscInfoGet(String lang) {
+                        return cscInfoApi.theApi().cscInfoGet(lang);
+                    }
+
+                    @Override
+                    public ApiResponse<CscInfoGet200Response> cscInfoGetWithHttpInfo(String lang) {
+                        return cscInfoApi.theApi().cscInfoGetWithHttpInfo(lang);
+                    }
+
+                    @Override
+                    public CscInfoGet200Response cscInfoGet(CscInfoGetQueryParams queryParams) {
+                        return cscInfoApi.theApi().cscInfoGet(queryParams);
+                    }
+
+                    @Override
+                    public ApiResponse<CscInfoGet200Response> cscInfoGetWithHttpInfo(CscInfoGetQueryParams queryParams) {
+                        return cscInfoApi.theApi().cscInfoGetWithHttpInfo(queryParams);
+                    }
+
+                    @Override
+                    public CscSignaturesSignHash200Response cscSignaturesSignHash(CscSignaturesSignHashRequest signaturesSignHashRequest) {
+                        return cscSignaturesApi.theApi().cscSignaturesSignHash(signaturesSignHashRequest);
+                    }
+
+                    @Override
+                    public ApiResponse<CscSignaturesSignHash200Response> cscSignaturesSignHashWithHttpInfo(CscSignaturesSignHashRequest signaturesSignHashRequest) {
+                        return cscSignaturesApi.theApi().cscSignaturesSignHashWithHttpInfo(signaturesSignHashRequest);
+                    }
+                });
     }
 
     /**

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/feignclients/B2bCscApi.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/feignclients/B2bCscApi.java
@@ -1,0 +1,8 @@
+package no.bankid.esign.merchant.b2b.feignclients;
+
+import no.bankid.esign.feign.api.b2b.csc.api.CscCredentialsApi;
+import no.bankid.esign.feign.api.b2b.csc.api.CscInfoApi;
+import no.bankid.esign.feign.api.b2b.csc.api.CscSignaturesApi;
+
+public interface B2bCscApi extends CscInfoApi, CscCredentialsApi, CscSignaturesApi {
+}

--- a/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/feignclients/FeignClientWithDPoPProofAndAccessToken.java
+++ b/b2b-client/src/main/java/no/bankid/esign/merchant/b2b/feignclients/FeignClientWithDPoPProofAndAccessToken.java
@@ -54,4 +54,8 @@ public class FeignClientWithDPoPProofAndAccessToken<ClientType> {
         return Base64.getEncoder().encodeToString(
             (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
     }
+
+    public ClientType theApi() {
+        return api;
+    }
 }


### PR DESCRIPTION
- Included b2b-csc openapi specification for clientgeneration
- Added simple example for pkcs1 generation based on a simple text 
- Validates the signature (not the ocsp) 
- Added sequence diagram for csc 
- Included csc in README.md 
- Hopefully enhanced comments